### PR TITLE
making this plugin compatible for redmine-4.0

### DIFF
--- a/app/controllers/cors_controller.rb
+++ b/app/controllers/cors_controller.rb
@@ -1,5 +1,5 @@
 class CorsController < ApplicationController
-  skip_before_filter :session_expiration, :user_setup, :check_if_login_required, :set_localization
+  skip_before_action :session_expiration, :user_setup, :check_if_login_required, :set_localization
 
   def preflight
     allowed_origins = Setting.plugin_redmine_cors["cors_domain"].to_s.downcase.split(/[ ,]/).reject { |c| c.empty? }

--- a/init.rb
+++ b/init.rb
@@ -20,7 +20,7 @@ Redmine::Plugin.register :redmine_cors do
   url 'http://github.com/mavimo/redmine_cors'
   author_url 'http://mavimo.org/'
 
-  version '0.0.1'
+  version '0.0.3'
   requires_redmine :version_or_higher => '2.0.0'
 
   settings :partial => 'settings/cors_settings',

--- a/lib/redmine_cors/patches/application_controller.rb
+++ b/lib/redmine_cors/patches/application_controller.rb
@@ -3,7 +3,7 @@ module RedmineCors
     module ApplicationController
       def self.included(base) # :nodoc:
         base.class_eval do
-          after_filter :cors_set_access_control_headers
+          after_action :cors_set_access_control_headers
         end
 
         base.send(:include, InstanceMethods)


### PR DESCRIPTION
redmine-4.0.0 uses Rails 5.2 and around filters are deprecated there.
This commit is to change the `_fitlers` to `_action`